### PR TITLE
Update gems for security vulnerability, remove dependency warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails', '~> 5.2.7'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server
-gem 'puma', '~> 3.11'
+gem "puma", ">= 4.3.12"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,8 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    puma (3.12.6)
+    puma (5.6.4)
+      nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.4)
     rack-test (2.0.2)
@@ -178,7 +179,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry
-  puma (~> 3.11)
+  puma (>= 4.3.12)
   rails (~> 5.2.7)
   rspec-rails
   shoulda-matchers

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,6 +4,6 @@ class Item < ApplicationRecord
   belongs_to :merchant
 
   def self.name_search_all(keyword)
-    where('LOWER(name) like ?', "%#{keyword.downcase}%")
+    where('name ilike ?', "%#{keyword.downcase}%")
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -4,8 +4,9 @@ class Merchant < ApplicationRecord
   has_many :items
 
   def self.name_search_first(keyword)
-    where('LOWER(name) like ?', "%#{keyword.downcase}%")
-      .order('LOWER(name)')
-      .first
+    where('name ilike ?', "%#{keyword.downcase}%")
+    .order(self.arel_table['name'].lower)
+    #.order('LOWER(name)') --> avoid deprecation warning
+    .first
   end
 end


### PR DESCRIPTION
Github has been alerting me to these:
![Screen Shot 2022-07-13 at 11 57 41 AM](https://user-images.githubusercontent.com/48455658/178778395-a116e696-a744-4d04-8af9-fb351d8f31ae.png)

So I have followed the directions to try and mitigate this. We will see how it goes!
I was also getting a deprecation warning `DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "LOWER(name)". Non-attribute arguments will be disallowed in Rails 6.0. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql(). (called from name_search_first at /Users/jenniferhalloran/turing/3mod/projects/rails-engine/app/models/merchant.rb:8)` for my .order('LOWER (name)') method so I refactored this as well. 
